### PR TITLE
Fix typo in a logging message

### DIFF
--- a/heaphopper/analysis/tracer/tracer.py
+++ b/heaphopper/analysis/tracer/tracer.py
@@ -717,7 +717,7 @@ def store_vuln_descs(desc_file, states, var_dict, arb_writes):
 
 # Store results as yaml-file
 def store_results(num_results, bin_file, states, var_dict, fd):
-    logger.info('Storing result infos to: {}.yaml'.format(bin_file))
+    logger.info('Storing result infos to: {}-result.yaml'.format(bin_file))
     results = []
     arbitrary_writes = []
     for i, state in enumerate(states):


### PR DESCRIPTION
Analysis results are saved in `{}-result.yaml`, not `{}.yaml`.